### PR TITLE
休憩打刻機能の実装と総勤務時間の計算機能修正

### DIFF
--- a/src/app/Http/Controllers/Employee/EmployeeAttendanceController.php
+++ b/src/app/Http/Controllers/Employee/EmployeeAttendanceController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Employee;
 
 use App\Http\Controllers\Controller;
 use App\Models\Attendance;
+use App\Models\BreakTime;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -25,17 +26,13 @@ class EmployeeAttendanceController extends Controller
         return view('employee.attendances.create', compact('date', 'time', 'user', 'statusLabel'));
     }
 
-    public function store()
+    public function recordWorkStart()
     {
-        /** @var \App\Models\User $user */
-        $user = Auth::user();
-        $now = Carbon::now();
-        $today = $now->toDateString();
-        $currentTime = $now->format('H:i:s');
-
-        $attendance = Attendance::where('user_id', $user->id)
-            ->whereDate('work_date', $today)
-            ->first();
+        $data = $this->getTodayAttendanceData();
+        $user = $data['user'];
+        $today = $data['today'];
+        $currentTime = $data['currentTime'];
+        $attendance = $data['attendance'];
 
         if ($attendance || !$user->isOffDuty()) {
             return redirect()->back()->with('error', '本日は出勤済みです');
@@ -54,17 +51,12 @@ class EmployeeAttendanceController extends Controller
         return redirect()->back();
     }
 
-    public function clockOut()
+    public function recordWorkEnd()
     {
-        /** @var \App\Models\User $user */
-        $user = Auth::user();
-        $now = Carbon::now();
-        $today = $now->toDateString();
-        $currentTime = $now->format('H:i:s');
-
-        $attendance = Attendance::where('user_id', $user->id)
-            ->whereDate('work_date', $today)
-            ->first();
+        $data = $this->getTodayAttendanceData();
+        $user = $data['user'];
+        $currentTime = $data['currentTime'];
+        $attendance = $data['attendance'];
 
         if (!$attendance) {
             return redirect()->back()->with('error', '本日の勤怠記録がありません');
@@ -78,15 +70,106 @@ class EmployeeAttendanceController extends Controller
         $clockOutTime = Carbon::parse($currentTime);
         $totalWorkMinutes = $clockInTime->diffInMinutes($clockOutTime);
 
-        DB::transaction(function () use ($user, $currentTime, $attendance, $totalWorkMinutes) {
+        $breakMinutes = $attendance->total_break_time ?? 0;
+        $netWorkMinutes = max(0, $totalWorkMinutes - $breakMinutes);
+
+        DB::transaction(function () use ($user, $currentTime, $attendance, $netWorkMinutes) {
             $attendance->update([
                 'clock_out' => $currentTime,
-                'total_work_time' => $totalWorkMinutes,
+                'total_work_time' => $netWorkMinutes,
             ]);
 
             $user->update(['work_status' => User::WORK_LEFT_WORK]);
         });
 
         return redirect()->back();
+    }
+
+    public function recordBreakStart()
+    {
+        $data = $this->getTodayAttendanceData();
+        $user = $data['user'];
+        $attendance = $data['attendance'];
+        $currentTime = $data['currentTime'];
+
+        if (!$attendance) {
+            return redirect()->back()->with('error', '本日の勤怠記録がありません');
+        }
+
+        if (!$user->isWorking()) {
+            return redirect()->back()->with('error', '勤務中ではないため休憩を記録できません');
+        }
+
+        DB::transaction(function () use ($user, $attendance, $currentTime) {
+            BreakTime::create([
+                'attendance_id' => $attendance->id,
+                'break_start' => $currentTime,
+            ]);
+
+            $user->update(['work_status' => User::WORK_ON_BREAK]);
+        });
+
+        return redirect()->back();
+    }
+
+    public function recordBreakEnd()
+    {
+        $data = $this->getTodayAttendanceData();
+        $user = $data['user'];
+        $attendance = $data['attendance'];
+        $currentTime = $data['currentTime'];
+
+        if (!$attendance) {
+            return redirect()->back()->with('error', '本日の勤怠記録がありません');
+        }
+
+        if (!$user->isOnBreak()) {
+            return redirect()->back()->with('error', '休憩中ではないため記録できません');
+        }
+
+        $latestBreak = $attendance->breakTimes()
+            ->whereNull('break_end')
+            ->latest('break_start')
+            ->first();
+
+        if (!$latestBreak) {
+            return redirect()->back()->with('error', '休憩開始記録が見つかりません');
+        }
+
+        $breakStart = Carbon::parse($latestBreak->break_start);
+        $breakEnd = Carbon::parse($currentTime);
+        $breakMinutes = $breakStart->diffInMinutes($breakEnd);
+
+        if (is_null($attendance->total_break_time)) {
+            $attendance->total_break_time = 0;
+            $attendance->save();
+        }
+
+        DB::transaction(function () use ($user, $attendance, $latestBreak, $breakEnd, $breakMinutes) {
+            $latestBreak->update([
+                'break_end' => $breakEnd->format('H:i:s'),
+            ]);
+
+            $attendance->increment('total_break_time', $breakMinutes);
+
+            $user->update(['work_status' => User::WORK_WORKING]);
+        });
+
+        return redirect()->back();
+    }
+
+    private function getTodayAttendanceData(): array
+    {
+        /** @var \App\Models\User $user */
+        $user = Auth::user();
+        $now = Carbon::now();
+        $today = $now->toDateString();
+        $currentTime = $now->format('H:i:s');
+
+        $attendance = Attendance::where('user_id', $user->id)
+            ->whereDate('work_date', $today)
+            ->first();
+
+        return compact('user', 'now', 'today', 'currentTime', 'attendance');
     }
 }

--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -30,7 +30,6 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\CheckAttendanceStatus::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,

--- a/src/resources/views/employee/attendances/create.blade.php
+++ b/src/resources/views/employee/attendances/create.blade.php
@@ -27,27 +27,28 @@
     </div>
 
     @if ($user->isOffDuty())
-    <form action="{{ route('attendance.store') }}" method="POST" class="attendance-main__form">
+    <form action="{{ route('attendance.work_start') }}" method="POST" class="attendance-main__form">
         @csrf
         <button type="submit" class="attendance-main__button">出勤</button>
     </form>
 
     @elseif ($user->isWorking())
     <div class="attendance-main__form-group">
-        <form action="{{ route('attendance.clock_out') }}" method="POST" class="attendance-main__form">
+        <form action="{{ route('attendance.work_end') }}" method="POST" class="attendance-main__form">
             @csrf
             @method('PATCH')
             <button type="submit" class="attendance-main__button">退勤</button>
         </form>
-        <form action="" method="POST" class="attendance-main__form">
+        <form action="{{ route('attendance.break_start') }}" method="POST" class="attendance-main__form">
             @csrf
             <button type="submit" class="attendance-main__button attendance-main__button--white">休憩入</button>
         </form>
     </div>
 
     @elseif ($user->isOnBreak())
-    <form action="" method="POST" class="attendance-main__form">
+    <form action="{{ route('attendance.break_end') }}" method="POST" class="attendance-main__form">
         @csrf
+        @method('PATCH')
         <button type="submit" class="attendance-main__button attendance-main__button--white">休憩戻</button>
     </form>
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Admin\AdminAttendanceController;
 use App\Http\Controllers\Auth\AdminLoginController;
 use App\Http\Controllers\Auth\EmployeeLoginController;
 use App\Http\Controllers\Employee\EmployeeAttendanceController;
+use App\Http\Middleware\CheckAttendanceStatus;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -19,14 +20,6 @@ use Illuminate\Support\Facades\Route;
 
 // 管理者用ルート
 Route::prefix('admin')->group(function () {
-    Route::get('/', function () {
-        if (Route::middleware('auth:admin')) {
-            return redirect()->route('admin.attendance.list');
-        } else {
-            return redirect()->route('admin.login');
-        }
-    });
-
     Route::middleware('guest:admin')->group(function () {
         Route::get('/login', [AdminLoginController::class, 'create'])->name('admin.login');
         Route::post('/login', [AdminLoginController::class, 'store']);
@@ -40,23 +33,22 @@ Route::prefix('admin')->group(function () {
 });
 
 // 一般ユーザー用ルート
-Route::get('/', function () {
-    if (Route::middleware('auth:web')) {
-        return redirect()->route('attendance.create');
-    } else {
-        return redirect()->route('login');
-    }
-});
-
 Route::middleware('guest:web')->group(function () {
     Route::get('/login', [EmployeeLoginController::class, 'create'])->name('login');
     Route::post('/login', [EmployeeLoginController::class, 'store']);
 });
 
+// 勤怠登録画面表示時にwork_statusチェックを実施
+Route::middleware(['auth:web', CheckAttendanceStatus::class])->group(function () {
+    Route::get('/attendance', [EmployeeAttendanceController::class, 'create'])->name('attendance.create');
+});
+
 Route::middleware('auth:web')->group(function () {
     Route::post('/logout', [EmployeeLoginController::class, 'destroy'])->name('logout');
 
-    Route::get('/attendance', [EmployeeAttendanceController::class, 'create'])->name('attendance.create');
-    Route::post('/attendance', [EmployeeAttendanceController::class, 'store'])->name('attendance.store');
-    Route::patch('/attendance/clock-out', [EmployeeAttendanceController::class, 'clockOut'])->name('attendance.clock_out');
+    Route::post('/attendance', [EmployeeAttendanceController::class, 'recordWorkStart'])->name('attendance.work_start');
+    Route::patch('/attendance', [EmployeeAttendanceController::class, 'recordWorkEnd'])->name('attendance.work_end');
+
+    Route::post('/attendance/break', [EmployeeAttendanceController::class, 'recordBreakStart'])->name('attendance.break_start');
+    Route::patch('/attendance/break', [EmployeeAttendanceController::class, 'recordBreakEnd'])->name('attendance.break_end');
 });


### PR DESCRIPTION
work_statusを当日の勤怠記録がなく、勤務外以外の場合に勤務外にセットするCheckAttendanceStatusミドルウェアを、勤怠登録画面を表示する際に適用しました。