### PR TITLE
[Issue #13] 管理者用スタッフ一覧画面作成

### DIFF
--- a/src/app/Http/Controllers/Admin/StaffController.php
+++ b/src/app/Http/Controllers/Admin/StaffController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class StaffController extends Controller
+{
+    //
+}

--- a/src/app/Http/Controllers/Admin/StaffController.php
+++ b/src/app/Http/Controllers/Admin/StaffController.php
@@ -3,9 +3,14 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Illuminate\Http\Request;
 
 class StaffController extends Controller
 {
-    //
+    public function index()
+    {
+        $staffs = User::all();
+        return view('admin.attendances.staff_list', compact('staffs'));
+    }
 }

--- a/src/public/css/admin/attendances/staff_list.css
+++ b/src/public/css/admin/attendances/staff_list.css
@@ -1,0 +1,69 @@
+.staff-list {
+    max-width: 930px;
+    margin: 0 auto;
+    padding: 50px 15px;
+}
+
+.staff-list__title {
+    font-size: 30px;
+    font-weight: bold;
+    padding-left: 20px;
+    margin: 60px 0;
+    border-left: 8px solid #000;
+}
+
+.staff-list__table-wrapper {
+    overflow-x: auto;
+    background-color: #fff;
+    border-radius: 10px;
+}
+
+.staff-list__table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 16px;
+    font-weight: bold;
+    color: #737373;
+    letter-spacing: 0.15em;
+}
+
+.staff-list__th {
+    padding: 12px 30px;
+    text-align: center;
+    border-bottom: 3px solid #e1e1e1;
+}
+
+.staff-list__td {
+    padding: 12px 30px;
+    text-align: center;
+    border-top: 2px solid #e1e1e1;
+}
+
+.staff-list__detail-link {
+    color: #000;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+}
+
+.staff-list__th:first-of-type,
+.staff-list__td:first-of-type {
+    padding-left: 100px;
+}
+
+.staff-list__th:last-of-type,
+.staff-list__td:last-of-type {
+    padding-right: 100px;
+}
+
+@media (max-width: 850px) {
+    .staff-list__th:first-of-type,
+    .staff-list__td:first-of-type {
+        padding-left: 50px;
+    }
+
+    .staff-list__th:last-of-type,
+    .staff-list__td:last-of-type {
+        padding-right: 50px;
+    }
+}

--- a/src/resources/views/admin/attendances/index.blade.php
+++ b/src/resources/views/admin/attendances/index.blade.php
@@ -72,7 +72,7 @@
                         </tr>
                     @empty
                         <tr class="attendance-index__tr">
-                            <td colspan="6" class="attendance-index__td attendance-index__id--empty">本日の勤怠記録はありません</td>
+                            <td colspan="6" class="attendance-index__td attendance-index__td--empty">本日の勤怠記録はありません</td>
                         </tr>
                     @endforelse
                 </tbody>

--- a/src/resources/views/admin/attendances/staff_list.blade.php
+++ b/src/resources/views/admin/attendances/staff_list.blade.php
@@ -1,1 +1,45 @@
-{{-- スタッフ一覧画面（管理者） --}}
+@extends('layouts/admin_app')
+
+@section('title')
+    スタッフ一覧
+@endsection
+
+@section('css')
+    {{-- staff_list.cssを作成し適用 --}}
+    <link rel="stylesheet" href="#">
+@endsection
+
+@section('content')
+    <div class="staff-list">
+        <h2 class="staff-list__title">スタッフ一覧</h2>
+
+        <div class="staff-list__table-wrapper">
+            <table class="staff-list__table">
+                <thead class="staff-list__thead">
+                    <tr class="staff-list__tr">
+                        <th class="staff-list__th">名前</th>
+                        <th class="staff-list__th">メールアドレス</th>
+                        <th class="staff-list__th">月次勤怠</th>
+                    </tr>
+                </thead>
+
+                <tbody class="staff-list__tbody">
+                    @forelse ($staffs as $staff)
+                        <tr class="staff-list__tr">
+                            <td class="staff-list__td">{{ $staff->name }}</td>
+                            <td class="staff-list__td">{{ $staff->email }}</td>
+                            {{-- 詳細でuser_idを持たせてユーザーの月次勤怠一覧画面へ遷移 --}}
+                            <td class="staff-list__td">
+                                <a href="#" class="staff-list__detail-link">詳細</a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr class="staff-list__tr">
+                            <td colspan="3" class="staff-list__td staff-list__td--empty">従業員がいません</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endsection

--- a/src/resources/views/admin/attendances/staff_list.blade.php
+++ b/src/resources/views/admin/attendances/staff_list.blade.php
@@ -5,8 +5,7 @@
 @endsection
 
 @section('css')
-    {{-- staff_list.cssを作成し適用 --}}
-    <link rel="stylesheet" href="#">
+    <link rel="stylesheet" href="{{ asset('css/admin/attendances/staff_list.css') }}">
 @endsection
 
 @section('content')

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Admin\AdminAttendanceController;
+use App\Http\Controllers\Admin\StaffController;
 use App\Http\Controllers\Auth\AdminLoginController;
 use App\Http\Controllers\Auth\EmployeeLoginController;
 use App\Http\Controllers\Employee\EmployeeAttendanceController;
@@ -33,6 +34,8 @@ Route::prefix('admin')->group(function () {
         Route::get('/attendance/list', [AdminAttendanceController::class, 'index'])->name('admin.attendance.list');
 
         Route::patch('/attendance/{id}', [AdminAttendanceController::class, 'update'])->name('admin.attendance.update');
+
+        Route::get('/staff/list', [StaffController::class, 'index'])->name('admin.staff.index');
     });
 });
 


### PR DESCRIPTION
Closes #13 

## 内容
- スタッフ一覧画面の作成
- CSSの適用
- 全一般ユーザーの情報取得メソッドの作成

## 備考
- 詳細を押下した時の画面遷移はissue 14で対応
