### PR TITLE
[Issue #14, #15]月次勤怠一覧画面の作成

### DIFF
--- a/src/app/Http/Controllers/Admin/StaffController.php
+++ b/src/app/Http/Controllers/Admin/StaffController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Attendance;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 
 class StaffController extends Controller
@@ -12,5 +14,26 @@ class StaffController extends Controller
     {
         $staffs = User::all();
         return view('admin.attendances.staff_list', compact('staffs'));
+    }
+
+    public function showMonthlyAttendance(Request $request, $id)
+    {
+        $staff = User::findOrFail($id);
+        $now = Carbon::now()->startOfMonth();
+        $monthParam = $request->input('month');
+
+        $currentDate = $monthParam
+            ? Carbon::parse($monthParam . '-01')
+            : $now;
+
+        $startOfMonth = $currentDate->copy()->startOfMonth();
+        $endOfMonth = $currentDate->copy()->endOfMonth();
+
+        $attendances = Attendance::where('user_id', $id)
+            ->whereBetween('work_date', [$startOfMonth, $endOfMonth])
+            ->orderBy('work_date')
+            ->get();
+
+        return view('admin.attendances.staff_attendance', compact('staff', 'currentDate', 'attendances'));
     }
 }

--- a/src/public/css/admin/attendances/index.css
+++ b/src/public/css/admin/attendances/index.css
@@ -1,1 +1,4 @@
-/* 勤怠一覧画面(管理者) */
+.attendance-index__th:first-of-type,
+.attendance-index__td:first-of-type {
+    text-align: center;
+}

--- a/src/public/css/admin/attendances/staff_attendance.css
+++ b/src/public/css/admin/attendances/staff_attendance.css
@@ -1,0 +1,18 @@
+.attendance-index__button {
+    margin: 50px 0;
+    text-align: right
+}
+
+.attendance-index__csv-export-button {
+    padding: 8px 22px;
+    width: 185px;
+    height: 50px;
+    background-color: #000;
+    color: #fff;
+    border-radius: 5px;
+    border: none;
+    font-size: 22px;
+    font-weight: bold;
+    letter-spacing: 0.15em;
+    cursor: pointer;
+}

--- a/src/resources/views/admin/attendances/index.blade.php
+++ b/src/resources/views/admin/attendances/index.blade.php
@@ -6,6 +6,7 @@
 
 @section('css')
     <link rel="stylesheet" href="{{ asset('css/attendances/index.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/admin/attendances/index.css') }}">
 @endsection
 
 @section('content')

--- a/src/resources/views/admin/attendances/staff_attendance.blade.php
+++ b/src/resources/views/admin/attendances/staff_attendance.blade.php
@@ -1,1 +1,88 @@
-{{-- スタッフ別勤怠一覧画面（管理者） --}}
+@extends('layouts/admin_app')
+
+@section('title')
+    {{ $staff->name }}さんの勤怠
+@endsection
+
+@section('css')
+    <link rel="stylesheet" href="{{ asset('css/attendances/index.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/admin/attendances/staff_attendance.css') }}">
+@endsection
+
+@section('content')
+    <div class="attendance-index">
+        <h2 class="attendance-index__title">{{ $staff->name }}さんの勤怠</h2>
+
+        <div class="attendance-index__nav">
+            <form action="{{ route('admin.staff.attendance.monthly', ['id' => $staff->id]) }}" method="GET" class="attendance-index__nav-form">
+                <input type="hidden" name="month" value="{{ $currentDate->copy()->subMonth()->format('Y-m') }}">
+                <button type="submit" class="attendance-index__nav-button">
+                    <x-fas-arrow-left class="attendance-index__nav-icon" />
+                    <p>前月</p>
+                </button>
+            </form>
+
+            <div class="attendance-index__current">
+                <x-radix-calendar class="attendance-index__calendar-icon" />
+                <p>{{ $currentDate->format('Y/m') }}</p>
+            </div>
+
+            <form action="{{ route('admin.staff.attendance.monthly', ['id' => $staff->id]) }}" method="GET" class="attendance-index__nav-form">
+                <input type="hidden" name="month" value="{{ $currentDate->copy()->addMonth()->format('Y-m') }}">
+                <button type="submit" class="attendance-index__nav-button">
+                    <p>翌月</p>
+                    <x-fas-arrow-right class="attendance-index__nav-icon" />
+                </button>
+            </form>
+        </div>
+
+        <div class="attendance-index__table-wrapper">
+            <table class="attendance-index__table">
+                <thead class="attendance-index__thead">
+                    <tr class="attendance-index__tr">
+                        <th class="attendance-index__th">日付</th>
+                        <th class="attendance-index__th">出勤</th>
+                        <th class="attendance-index__th">退勤</th>
+                        <th class="attendance-index__th">休憩</th>
+                        <th class="attendance-index__th">合計</th>
+                        <th class="attendance-index__th">詳細</th>
+                    </tr>
+                </thead>
+
+                <tbody>
+                    @forelse ($attendances as $attendance)
+                        <tr class="attendance-index__tr">
+                            <td class="attendance-index__td">
+                                {{ $attendance->formatted_work_date }}
+                            </td>
+                            <td class="attendance-index__td">
+                                {{ $attendance->clock_in ? $attendance->formatted_clock_in : '' }}
+                            </td>
+                            <td class="attendance-index__td">
+                                {{ $attendance->clock_out ? $attendance->formatted_clock_out : '' }}
+                            </td>
+                            <td class="attendance-index__td">
+                                {{ $attendance->formatted_total_break_time }}
+                            </td>
+                            <td class="attendance-index__td">
+                                {{ $attendance->formatted_total_work_time }}
+                            </td>
+                            <td class="attendance-index__td">
+                                <a href="{{ route('attendance.modification.show', ['id' => $attendance->id]) }}" class="attendance-index__detail-link">詳細</a>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr class="attendance-index__tr">
+                            <td colspan="6" class="attendance-index__td attendance-index__td--empty">当月の勤怠記録はありません</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        <div class="attendance-index__button">
+            {{-- 応用機能: 当該ユーザーの選択した月の勤怠情報をCSVでダウンロード --}}
+            <button type="submit" class="attendance-index__csv-export-button">CSV出力</button>
+        </div>
+    </div>
+@endsection

--- a/src/resources/views/admin/attendances/staff_list.blade.php
+++ b/src/resources/views/admin/attendances/staff_list.blade.php
@@ -29,7 +29,7 @@
                             <td class="staff-list__td">{{ $staff->email }}</td>
                             {{-- 詳細でuser_idを持たせてユーザーの月次勤怠一覧画面へ遷移 --}}
                             <td class="staff-list__td">
-                                <a href="#" class="staff-list__detail-link">詳細</a>
+                                <a href="{{ route('admin.staff.attendance.monthly', ['id' => $staff->id]) }}" class="staff-list__detail-link">詳細</a>
                             </td>
                         </tr>
                     @empty

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -36,6 +36,7 @@ Route::prefix('admin')->group(function () {
         Route::patch('/attendance/{id}', [AdminAttendanceController::class, 'update'])->name('admin.attendance.update');
 
         Route::get('/staff/list', [StaffController::class, 'index'])->name('admin.staff.index');
+        Route::get('/attendance/staff/{id}', [StaffController::class, 'showMonthlyAttendance'])->name('admin.staff.attendance.monthly');
     });
 });
 


### PR DESCRIPTION
Closes #14 
Closes #15 

## 内容
- 月次勤怠一覧画面の作成
- ルーティングの設定
- 勤怠データ取得メソッド作成
- CSSの適用
- 詳細ボタンを押下すると勤怠詳細画面に遷移

## 備考
CSV出力機能は最終修正時に実装