### PR TITLE
[Issue #23]Deprecated: PHP Startupエラーを解決する

### DIFF
--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,5 +1,5 @@
 date.timezone = "Asia/Tokyo"
+default_charset = "UTF-8"
 
 [mbstring]
-mbstring.internal_encoding = "UTF-8"
 mbstring.language = "Japanese"


### PR DESCRIPTION
Closes #23 
この変更後`docker-compose up -d --build`で再ビルドしてください。

## 内容
- php.iniの`mbstring.internal_encoding = UTF-8` を削除しました
- `default_charset = "UTF-8"`を追加しました

## 備考
mbstring.internal_encodingはPHP 5.6.0以降で非推奨となっていたため、削除しました。
代わりにdefault_charsetでUTF-8を指定しました。
